### PR TITLE
CCSDS 133.0-B-2 - Space Packet Protocol

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,11 @@
+If you believe you have found a security vulnerability in this project, you can report it to us directly using [private vulnerability reporting][].
+
+- Include a description of your investigation of this project's codebase and why you believe an exploit is possible.
+- POCs and links to code are greatly encouraged.
+- Such reports are not eligible for a bounty reward.
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Thanks for helping make Astro safe for everyone.
+
+[private vulnerability reporting]: https://github.com/ravisuhag/astro/security/advisories

--- a/.github/workflows/liint.yaml
+++ b/.github/workflows/liint.yaml
@@ -1,0 +1,29 @@
+name: Lint
+on:
+  push:
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
+  pull_request:
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Run unit tests
+        run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 
 # env file
 .env
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ravisuhag/astro
+
+go 1.23.5

--- a/spp/apid.go
+++ b/spp/apid.go
@@ -1,0 +1,66 @@
+package spp
+
+import (
+	"errors"
+	"sync"
+)
+
+// APIDManager manages the allocation and validation of APIDs.
+type APIDManager struct {
+	reserved map[uint16]bool
+	mutex    sync.Mutex
+}
+
+// NewAPIDManager creates a new APIDManager instance.
+func NewAPIDManager() *APIDManager {
+	return &APIDManager{
+		reserved: make(map[uint16]bool),
+	}
+}
+
+// ReserveAPID reserves an APID.
+func (m *APIDManager) ReserveAPID(apid uint16) error {
+	if apid > 2047 {
+		return errors.New("invalid APID: must be in range 0-2047")
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.reserved[apid] {
+		return errors.New("APID is already reserved")
+	}
+
+	m.reserved[apid] = true
+	return nil
+}
+
+// ReleaseAPID releases a reserved APID.
+func (m *APIDManager) ReleaseAPID(apid uint16) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	delete(m.reserved, apid)
+}
+
+// IsAPIDReserved checks if an APID is reserved.
+func (m *APIDManager) IsAPIDReserved(apid uint16) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.reserved[apid]
+}
+
+// DescribeAPID provides a description for a given APID.
+func DescribeAPID(apid uint16) string {
+	switch apid {
+	case 0:
+		return "Idle Packet"
+	case 1:
+		return "Telemetry Packet"
+	case 2:
+		return "Command Packet"
+	default:
+		return "Unknown or Custom Packet"
+	}
+}

--- a/spp/apid_test.go
+++ b/spp/apid_test.go
@@ -1,0 +1,87 @@
+package spp_test
+
+import (
+	"github.com/ravisuhag/astro/spp"
+	"testing"
+)
+
+func TestNewAPIDManager(t *testing.T) {
+	manager := spp.NewAPIDManager()
+	if manager == nil {
+		t.Fatal("Expected non-nil APIDManager instance")
+	}
+}
+
+func TestReserveAPID(t *testing.T) {
+	manager := spp.NewAPIDManager()
+
+	err := manager.ReserveAPID(100)
+	if err != nil {
+		t.Fatalf("Failed to reserve APID: %v", err)
+	}
+
+	if !manager.IsAPIDReserved(100) {
+		t.Errorf("Expected APID 100 to be reserved")
+	}
+
+	err = manager.ReserveAPID(100)
+	if err == nil {
+		t.Errorf("Expected error when reserving already reserved APID")
+	}
+
+	err = manager.ReserveAPID(2048)
+	if err == nil {
+		t.Errorf("Expected error when reserving invalid APID")
+	}
+}
+
+func TestReleaseAPID(t *testing.T) {
+	manager := spp.NewAPIDManager()
+
+	err := manager.ReserveAPID(100)
+	if err != nil {
+		t.Fatalf("Failed to reserve APID: %v", err)
+	}
+
+	manager.ReleaseAPID(100)
+
+	if manager.IsAPIDReserved(100) {
+		t.Errorf("Expected APID 100 to be released")
+	}
+}
+
+func TestIsAPIDReserved(t *testing.T) {
+	manager := spp.NewAPIDManager()
+
+	if manager.IsAPIDReserved(100) {
+		t.Errorf("Expected APID 100 to be not reserved initially")
+	}
+
+	err := manager.ReserveAPID(100)
+	if err != nil {
+		t.Fatalf("Failed to reserve APID: %v", err)
+	}
+
+	if !manager.IsAPIDReserved(100) {
+		t.Errorf("Expected APID 100 to be reserved")
+	}
+}
+
+func TestDescribeAPID(t *testing.T) {
+	tests := []struct {
+		apid     uint16
+		expected string
+	}{
+		{0, "Idle Packet"},
+		{1, "Telemetry Packet"},
+		{2, "Command Packet"},
+		{999, "Unknown or Custom Packet"},
+	}
+
+	for _, test := range tests {
+		description := spp.DescribeAPID(test.apid)
+		if description != test.expected {
+			t.Errorf("Expected description %q, got %q", test.expected, description)
+		}
+	}
+}

--- a/spp/errors.go
+++ b/spp/errors.go
@@ -1,0 +1,25 @@
+package spp
+
+import "errors"
+
+// Custom error definitions for the spp package.
+
+var (
+	// ErrInvalidHeader indicates an invalid primary or secondary header.
+	ErrInvalidHeader = errors.New("invalid header: header does not conform to CCSDS standards")
+
+	// ErrInvalidAPID indicates that the provided APID is out of range or invalid.
+	ErrInvalidAPID = errors.New("invalid APID: must be in the range 0-2047")
+
+	// ErrPacketTooLarge indicates that the packet size exceeds the allowable limit.
+	ErrPacketTooLarge = errors.New("packet size exceeds the maximum allowable limit")
+
+	// ErrDataTooShort indicates that the provided data is too short for decoding.
+	ErrDataTooShort = errors.New("provided data is too short to decode the packet")
+
+	// ErrSecondaryHeaderMissing indicates that a required secondary header is missing.
+	ErrSecondaryHeaderMissing = errors.New("secondary header flag is set but no secondary header is provided")
+
+	// ErrCRCValidationFailed indicates that the CRC validation of the packet failed.
+	ErrCRCValidationFailed = errors.New("CRC validation failed: data integrity check failed")
+)

--- a/spp/header.go
+++ b/spp/header.go
@@ -4,36 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"strconv"
+	"strings"
 )
-
-/*
-the Space Packet Protocol (SPP):
-
-+----------------+----------------+----------------+----------------+
-| Version (3b)  | Type (1b)      | SecondaryHeader| APID (11b)     |
-|               |                | Flag (1b)      |                |
-+----------------+----------------+----------------+----------------+
-| Sequence Flags| Sequence Count (14b)                            |
-| (2b)          |                                                 |
-+----------------+----------------+----------------+----------------+
-| Packet Length (16b)                                             |
-+----------------+----------------+----------------+----------------+
-| Secondary Header (Optional, mission-specific)                  |
-|                                                                |
-+----------------+----------------+----------------+----------------+
-| User Data Field (Variable Length)                              |
-|                                                                |
-|                                                                |
-+----------------+----------------+----------------+----------------+
-| Error Control Field (Optional, 16b CRC)                       |
-+----------------+----------------+----------------+----------------+
-
-Legend:
-- b = bits
-- APID = Application Process Identifier
-- Sequence Flags: 00 (continuation), 01 (start), 10 (end), 11 (standalone)
-- Packet Length: Total length of the packet minus the primary header (6 bytes)
-*/
 
 // PrimaryHeader represents the mandatory header section of a space packet.
 type PrimaryHeader struct {
@@ -98,6 +71,19 @@ func (ph *PrimaryHeader) Decode(data []byte) error {
 	ph.PacketLength = uint16(data[4])<<8 | uint16(data[5])
 
 	return nil
+}
+
+// Humanize generates a human-readable representation of the PrimaryHeader.
+func (ph *PrimaryHeader) Humanize() string {
+	return strings.Join([]string{
+		"  Version: " + strconv.Itoa(int(ph.Version)),
+		"  Type: " + strconv.Itoa(int(ph.Type)),
+		"  Secondary Header Flag: " + strconv.Itoa(int(ph.SecondaryHeaderFlag)),
+		"  APID: " + strconv.Itoa(int(ph.APID)),
+		"  Sequence Flags: " + strconv.Itoa(int(ph.SequenceFlags)),
+		"  Sequence Count: " + strconv.Itoa(int(ph.SequenceCount)),
+		"  Packet Length: " + strconv.Itoa(int(ph.PacketLength)),
+	}, "\n")
 }
 
 // SecondaryHeader represents the optional customizable secondary header of a space packet.
@@ -193,4 +179,12 @@ func (sh *SecondaryHeader) Decode(data []byte) error {
 		}
 	}
 	return nil
+}
+
+// Humanize generates a human-readable representation of the SecondaryHeader.
+func (sh *SecondaryHeader) Humanize() string {
+	return strings.Join([]string{
+		"  Timestamp: " + strconv.FormatUint(sh.Timestamp, 10),
+		"  Other Fields: " + mapToString(sh.OtherFields),
+	}, "\n")
 }

--- a/spp/header.go
+++ b/spp/header.go
@@ -1,0 +1,196 @@
+package spp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+/*
+the Space Packet Protocol (SPP):
+
++----------------+----------------+----------------+----------------+
+| Version (3b)  | Type (1b)      | SecondaryHeader| APID (11b)     |
+|               |                | Flag (1b)      |                |
++----------------+----------------+----------------+----------------+
+| Sequence Flags| Sequence Count (14b)                            |
+| (2b)          |                                                 |
++----------------+----------------+----------------+----------------+
+| Packet Length (16b)                                             |
++----------------+----------------+----------------+----------------+
+| Secondary Header (Optional, mission-specific)                  |
+|                                                                |
++----------------+----------------+----------------+----------------+
+| User Data Field (Variable Length)                              |
+|                                                                |
+|                                                                |
++----------------+----------------+----------------+----------------+
+| Error Control Field (Optional, 16b CRC)                       |
++----------------+----------------+----------------+----------------+
+
+Legend:
+- b = bits
+- APID = Application Process Identifier
+- Sequence Flags: 00 (continuation), 01 (start), 10 (end), 11 (standalone)
+- Packet Length: Total length of the packet minus the primary header (6 bytes)
+*/
+
+// PrimaryHeader represents the mandatory header section of a space packet.
+type PrimaryHeader struct {
+	Version             uint8  // Protocol version (3 bits)
+	Type                uint8  // Packet type (1 bit)
+	SecondaryHeaderFlag uint8  // Indicates if a secondary header is present (1 bit)
+	APID                uint16 // Application Process Identifier (11 bits)
+	SequenceFlags       uint8  // Packet sequence control flags (2 bits)
+	SequenceCount       uint16 // Packet sequence number (14 bits)
+	PacketLength        uint16 // Total packet length minus the primary header (16 bits)
+}
+
+// Encode serializes the PrimaryHeader into a 6-byte array.
+func (ph *PrimaryHeader) Encode() ([]byte, error) {
+	if ph.SecondaryHeaderFlag > 1 {
+		return nil, errors.New("SecondaryHeaderFlag must be 0 or 1")
+	}
+	if ph.APID > 0x07FF {
+		return nil, errors.New("APID exceeds 11 bits")
+	}
+	if ph.SequenceCount > 0x3FFF {
+		return nil, errors.New("SequenceCount exceeds 14 bits")
+	}
+
+	buf := make([]byte, 6)
+
+	// Encode the first byte (Version, Type, SecondaryHeaderFlag, first 3 bits of APID)
+	buf[0] = (ph.Version << 5) | (ph.Type << 4) | (ph.SecondaryHeaderFlag << 3) | uint8((ph.APID>>8)&0x07)
+
+	// Encode the next byte (remaining 8 bits of APID)
+	buf[1] = uint8(ph.APID & 0xFF)
+
+	// Encode the third byte (SequenceFlags and first 6 bits of SequenceCount)
+	buf[2] = (ph.SequenceFlags << 6) | uint8((ph.SequenceCount>>8)&0x3F)
+
+	// Encode the fourth byte (remaining 8 bits of SequenceCount)
+	buf[3] = uint8(ph.SequenceCount & 0xFF)
+
+	// Encode the PacketLength (2 bytes)
+	buf[4] = uint8(ph.PacketLength >> 8)   // Most significant byte
+	buf[5] = uint8(ph.PacketLength & 0xFF) // Least significant byte
+	return buf, nil
+}
+
+// Decode deserializes a 6-byte array into a PrimaryHeader.
+func (ph *PrimaryHeader) Decode(data []byte) error {
+	if len(data) < 6 {
+		return errors.New("data too short to decode primary header")
+	}
+
+	// Decode the first byte (Version, Type, SecondaryHeaderFlag, first 3 bits of APID)
+	ph.Version = data[0] >> 5
+	ph.Type = (data[0] >> 4) & 0x01
+	ph.SecondaryHeaderFlag = (data[0] >> 3) & 0x01
+	ph.APID = uint16(data[0]&0x07)<<8 | uint16(data[1])
+
+	// Decode the third byte (SequenceFlags and first 6 bits of SequenceCount)
+	ph.SequenceFlags = data[2] >> 6
+	ph.SequenceCount = uint16(data[2]&0x3F)<<8 | uint16(data[3])
+
+	// Decode the PacketLength (2 bytes)
+	ph.PacketLength = uint16(data[4])<<8 | uint16(data[5])
+
+	return nil
+}
+
+// SecondaryHeader represents the optional customizable secondary header of a space packet.
+type SecondaryHeader struct {
+	Timestamp   uint64                 // Optional timestamp for mission-specific data
+	OtherFields map[string]interface{} // Additional mission-specific fields
+}
+
+// Encode serializes the SecondaryHeader into a byte slice.
+func (sh *SecondaryHeader) Encode() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Encode Timestamp
+	if err := binary.Write(buf, binary.BigEndian, sh.Timestamp); err != nil {
+		return nil, err
+	}
+
+	// Encode the OtherFields
+	for key, value := range sh.OtherFields {
+		keyLen := uint16(len(key))
+		if err := binary.Write(buf, binary.BigEndian, keyLen); err != nil {
+			return nil, errors.New("failed to encode field key length")
+		}
+		if _, err := buf.WriteString(key); err != nil {
+			return nil, errors.New("failed to encode field key")
+		}
+
+		switch v := value.(type) {
+		case string:
+			valueType := uint8(1) // Type 1 = string
+			if err := binary.Write(buf, binary.BigEndian, valueType); err != nil {
+				return nil, errors.New("failed to encode value type")
+			}
+			valueLen := uint16(len(v))
+			if err := binary.Write(buf, binary.BigEndian, valueLen); err != nil {
+				return nil, errors.New("failed to encode value length")
+			}
+			if _, err := buf.WriteString(v); err != nil {
+				return nil, errors.New("failed to encode string value")
+			}
+		default:
+			return nil, errors.New("unsupported field value type")
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Decode deserializes a byte slice into a SecondaryHeader.
+func (sh *SecondaryHeader) Decode(data []byte) error {
+	if len(data) < 8 {
+		return errors.New("data too short to decode secondary header")
+	}
+
+	buf := bytes.NewReader(data)
+
+	// Decode the timestamp
+	if err := binary.Read(buf, binary.BigEndian, &sh.Timestamp); err != nil {
+		return errors.New("failed to decode timestamp")
+	}
+
+	sh.OtherFields = make(map[string]interface{})
+
+	// Decode the OtherFields
+	for buf.Len() > 0 {
+		var keyLen uint16
+		if err := binary.Read(buf, binary.BigEndian, &keyLen); err != nil {
+			return errors.New("failed to decode field key length")
+		}
+		key := make([]byte, keyLen)
+		if _, err := buf.Read(key); err != nil {
+			return errors.New("failed to decode field key")
+		}
+
+		var valueType uint8
+		if err := binary.Read(buf, binary.BigEndian, &valueType); err != nil {
+			return errors.New("failed to decode value type")
+		}
+
+		switch valueType {
+		case 1: // String
+			var valueLen uint16
+			if err := binary.Read(buf, binary.BigEndian, &valueLen); err != nil {
+				return errors.New("failed to decode value length")
+			}
+			value := make([]byte, valueLen)
+			if _, err := buf.Read(value); err != nil {
+				return errors.New("failed to decode string value")
+			}
+			sh.OtherFields[string(key)] = string(value)
+		default:
+			return errors.New("unsupported field value type")
+		}
+	}
+	return nil
+}

--- a/spp/header_test.go
+++ b/spp/header_test.go
@@ -1,0 +1,147 @@
+package spp_test
+
+import (
+	"github.com/ravisuhag/astro/spp"
+	"testing"
+)
+
+func TestPrimaryHeaderEncodeDecode(t *testing.T) {
+	original := &spp.PrimaryHeader{
+		Version:             0,
+		Type:                1,
+		SecondaryHeaderFlag: 0,
+		APID:                2047,
+		SequenceFlags:       3,
+		SequenceCount:       16383,
+		PacketLength:        1023,
+	}
+
+	encoded, err := original.Encode()
+	if err != nil {
+		t.Fatalf("Failed to encode primary header: %v", err)
+	}
+
+	decoded := &spp.PrimaryHeader{}
+	err = decoded.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Failed to decode primary header: %v", err)
+	}
+
+	if *original != *decoded {
+		t.Errorf("Decoded primary header does not match original. Got %+v, want %+v", decoded, original)
+	}
+}
+
+func TestPrimaryHeaderSecondaryHeaderFlag(t *testing.T) {
+	tests := []struct {
+		flag    uint8
+		isValid bool
+	}{
+		{0, true},
+		{1, true},
+		{2, false},
+		{255, false},
+	}
+
+	for _, test := range tests {
+		ph := &spp.PrimaryHeader{
+			Version:             1,
+			Type:                1,
+			SecondaryHeaderFlag: test.flag,
+			APID:                2047,
+			SequenceFlags:       3,
+			SequenceCount:       16383,
+			PacketLength:        1023,
+		}
+
+		_, err := ph.Encode()
+		if test.isValid && err != nil {
+			t.Errorf("Expected valid flag %d, but got error: %v", test.flag, err)
+		} else if !test.isValid && err == nil {
+			t.Errorf("Expected error for invalid flag %d, but got none", test.flag)
+		}
+	}
+}
+
+func TestPrimaryHeaderAPID(t *testing.T) {
+	tests := []struct {
+		apid    uint16
+		isValid bool
+	}{
+		{0, true},
+		{2047, true},
+		{2048, false},
+		{65535, false},
+	}
+
+	for _, test := range tests {
+		ph := &spp.PrimaryHeader{
+			Version:             1,
+			Type:                1,
+			SecondaryHeaderFlag: 0,
+			APID:                test.apid,
+			SequenceFlags:       3,
+			SequenceCount:       16383,
+			PacketLength:        1023,
+		}
+
+		_, err := ph.Encode()
+		if test.isValid && err != nil {
+			t.Errorf("Expected valid APID %d, but got error: %v", test.apid, err)
+		} else if !test.isValid && err == nil {
+			t.Errorf("Expected error for invalid APID %d, but got none", test.apid)
+		}
+	}
+}
+
+func TestPrimaryHeaderSequenceCount(t *testing.T) {
+	tests := []struct {
+		sequenceCount uint16
+		isValid       bool
+	}{
+		{0, true},
+		{16383, true},
+		{16384, false},
+		{65535, false},
+	}
+
+	for _, test := range tests {
+		ph := &spp.PrimaryHeader{
+			Version:             1,
+			Type:                1,
+			SecondaryHeaderFlag: 0,
+			APID:                2047,
+			SequenceFlags:       3,
+			SequenceCount:       test.sequenceCount,
+			PacketLength:        1023,
+		}
+
+		_, err := ph.Encode()
+		if test.isValid && err != nil {
+			t.Errorf("Expected valid SequenceCount %d, but got error: %v", test.sequenceCount, err)
+		} else if !test.isValid && err == nil {
+			t.Errorf("Expected error for invalid SequenceCount %d, but got none", test.sequenceCount)
+		}
+	}
+}
+
+func TestSecondaryHeaderEncodeDecode(t *testing.T) {
+	original := &spp.SecondaryHeader{
+		Timestamp: 1234567890,
+	}
+
+	encoded, err := original.Encode()
+	if err != nil {
+		t.Fatalf("Failed to encode secondary header: %v", err)
+	}
+
+	decoded := &spp.SecondaryHeader{}
+	err = decoded.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Failed to decode secondary header: %v", err)
+	}
+
+	if original.Timestamp != decoded.Timestamp {
+		t.Errorf("Decoded secondary header does not match original. Got %+v, want %+v", decoded, original)
+	}
+}

--- a/spp/packet.go
+++ b/spp/packet.go
@@ -3,6 +3,8 @@ package spp
 import (
 	"errors"
 	"io"
+	"strconv"
+	"strings"
 )
 
 /*
@@ -201,4 +203,27 @@ func ReceivePacket(reader io.Reader) (*SpacePacket, error) {
 	}
 
 	return Decode(buffer[:n])
+}
+
+// Humanize generates a human-readable representation of the SpacePacket.
+func (sp *SpacePacket) Humanize() string {
+	var builder strings.Builder
+	builder.WriteString("SpacePacket Information:\n")
+	builder.WriteString("Primary Header:\n")
+	builder.WriteString(sp.PrimaryHeader.Humanize())
+
+	if sp.SecondaryHeader != nil {
+		builder.WriteString("\nSecondary Header:\n")
+		builder.WriteString(sp.SecondaryHeader.Humanize())
+	}
+
+	builder.WriteString("\nUser Data Length: ")
+	builder.WriteString(strconv.Itoa(len(sp.UserData)))
+
+	if sp.ErrorControl != nil {
+		builder.WriteString("\nError Control: ")
+		builder.WriteString(strconv.Itoa(int(*sp.ErrorControl)))
+	}
+
+	return builder.String()
 }

--- a/spp/packet.go
+++ b/spp/packet.go
@@ -1,0 +1,204 @@
+package spp
+
+import (
+	"errors"
+	"io"
+)
+
+/*
+Space Packet Protocol (SPP):
+
++----------------+----------------+----------------+----------------+
+| Version (3b)  | Type (1b)      | SecondaryHeader| APID (11b)     |
+|               |                | Flag (1b)      |                |
++----------------+----------------+----------------+----------------+
+| Sequence Flags| Sequence Count (14b)                            |
+| (2b)          |                                                 |
++----------------+----------------+----------------+----------------+
+| Packet Length (16b)                                             |
++----------------+----------------+----------------+----------------+
+| Secondary Header (Optional, mission-specific)                  |
+|                                                                |
++----------------+----------------+----------------+----------------+
+| User Data Field (Variable Length)                              |
+|                                                                |
+|                                                                |
++----------------+----------------+----------------+----------------+
+| Error Control Field (Optional, 16b CRC)                       |
++----------------+----------------+----------------+----------------+
+
+Legend:
+- b = bits
+- APID = Application Process Identifier
+- Sequence Flags: 00 (continuation), 01 (start), 10 (end), 11 (standalone)
+- Packet Length: Total length of the packet minus the primary header (6 bytes)
+*/
+
+// SpacePacket represents a complete space packet as per CCSDS standards.
+type SpacePacket struct {
+	PrimaryHeader   PrimaryHeader    // The primary header of the space packet
+	SecondaryHeader *SecondaryHeader // Optional secondary header
+	UserData        []byte           // User data contained in the packet
+	ErrorControl    *uint16          // Optional error control field (e.g., CRC)
+}
+
+// NewSpacePacket creates a new SpacePacket instance.
+func NewSpacePacket(apid uint16, data []byte, options ...PacketOption) (*SpacePacket, error) {
+	if apid > 2047 {
+		return nil, errors.New("invalid APID: must be in range 0-2047")
+	}
+
+	// Default primary header
+	primaryHeader := PrimaryHeader{
+		Version:             0,
+		Type:                0,
+		SecondaryHeaderFlag: 0,
+		APID:                apid,
+		SequenceFlags:       3, // Default sequence flag (standalone packet)
+		SequenceCount:       0,
+		PacketLength:        uint16(len(data)),
+	}
+
+	// Initialize SpacePacket
+	packet := &SpacePacket{
+		PrimaryHeader: primaryHeader,
+		UserData:      data,
+	}
+
+	// Apply optional configurations
+	for _, option := range options {
+		if err := option(packet); err != nil {
+			return nil, err
+		}
+	}
+
+	return packet, nil
+}
+
+// PacketOption defines a function type for configuring SpacePacket options.
+type PacketOption func(*SpacePacket) error
+
+// WithSecondaryHeader adds a secondary header to the SpacePacket.
+func WithSecondaryHeader(header SecondaryHeader) PacketOption {
+	return func(packet *SpacePacket) error {
+		packet.PrimaryHeader.SecondaryHeaderFlag = 1
+		packet.SecondaryHeader = &header
+		return nil
+	}
+}
+
+// WithErrorControl adds an error control field to the SpacePacket.
+func WithErrorControl(crc uint16) PacketOption {
+	return func(packet *SpacePacket) error {
+		packet.ErrorControl = &crc
+		return nil
+	}
+}
+
+// Encode converts the SpacePacket into a byte slice for transmission.
+func (sp *SpacePacket) Encode() ([]byte, error) {
+	// Encode primary header
+	headerBytes, err := sp.PrimaryHeader.Encode()
+	if err != nil {
+		return nil, ErrInvalidHeader
+	}
+
+	packetData := append([]byte{}, headerBytes...)
+
+	// Encode secondary header if present
+	if sp.PrimaryHeader.SecondaryHeaderFlag == 1 && sp.SecondaryHeader != nil {
+		secondaryBytes, err := sp.SecondaryHeader.Encode()
+		if err != nil {
+			return nil, ErrInvalidHeader
+		}
+		packetData = append(packetData, secondaryBytes...)
+	} else if sp.PrimaryHeader.SecondaryHeaderFlag == 1 && sp.SecondaryHeader == nil {
+		return nil, ErrSecondaryHeaderMissing
+	}
+
+	// Append user data
+	packetData = append(packetData, sp.UserData...)
+
+	// Append error control field if present
+	if sp.ErrorControl != nil {
+		crcBytes := make([]byte, 2)
+		crcBytes[0] = byte(*sp.ErrorControl >> 8)
+		crcBytes[1] = byte(*sp.ErrorControl & 0xFF)
+		packetData = append(packetData, crcBytes...)
+	}
+
+	return packetData, nil
+}
+
+// Decode parses a byte slice into a SpacePacket.
+func Decode(data []byte) (*SpacePacket, error) {
+	if len(data) < 6 {
+		return nil, ErrDataTooShort
+	}
+
+	// Decode primary header
+	primaryHeader := PrimaryHeader{}
+	if err := primaryHeader.Decode(data[:6]); err != nil {
+		return nil, ErrInvalidHeader
+	}
+
+	offset := 6
+	var secondaryHeader *SecondaryHeader
+
+	// Decode secondary header if flag is set
+	if primaryHeader.SecondaryHeaderFlag == 1 {
+		if len(data) < offset+8 {
+			return nil, ErrDataTooShort
+		}
+		secondaryHeader = &SecondaryHeader{}
+		if err := secondaryHeader.Decode(data[offset : offset+8]); err != nil {
+			return nil, ErrInvalidHeader
+		}
+		offset += 8
+	}
+
+	// Extract user data
+	userDataEnd := len(data)
+	if primaryHeader.PacketLength+6 < uint16(len(data)) {
+		userDataEnd = int(primaryHeader.PacketLength) + 6
+	}
+	userData := data[offset:userDataEnd]
+
+	offset += len(userData)
+
+	// Parse error control if present
+	var errorControl *uint16
+	if len(data) >= offset+2 {
+		crc := uint16(data[offset])<<8 | uint16(data[offset+1])
+		errorControl = &crc
+	}
+
+	return &SpacePacket{
+		PrimaryHeader:   primaryHeader,
+		SecondaryHeader: secondaryHeader,
+		UserData:        userData,
+		ErrorControl:    errorControl,
+	}, nil
+}
+
+// SendPacket writes a SpacePacket to an io.Writer.
+func SendPacket(packet *SpacePacket, writer io.Writer) error {
+	data, err := packet.Encode()
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(data)
+	return err
+}
+
+// ReceivePacket reads a SpacePacket from an io.Reader.
+func ReceivePacket(reader io.Reader) (*SpacePacket, error) {
+	buffer := make([]byte, 65542) // Maximum possible packet size
+	n, err := reader.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	return Decode(buffer[:n])
+}

--- a/spp/packet_test.go
+++ b/spp/packet_test.go
@@ -1,0 +1,106 @@
+package spp_test
+
+import (
+	"bytes"
+	"github.com/ravisuhag/astro/spp"
+	"testing"
+)
+
+func TestNewSpacePacket(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	packet, err := spp.NewSpacePacket(100, data)
+	if err != nil {
+		t.Fatalf("Failed to create new space packet: %v", err)
+	}
+
+	if packet.PrimaryHeader.APID != 100 {
+		t.Errorf("Expected APID 100, got %d", packet.PrimaryHeader.APID)
+	}
+
+	if !bytes.Equal(packet.UserData, data) {
+		t.Errorf("User data does not match. Got %v, want %v", packet.UserData, data)
+	}
+}
+
+func TestSpacePacketEncodeDecode(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	packet, err := spp.NewSpacePacket(100, data)
+	if err != nil {
+		t.Fatalf("Failed to create new space packet: %v", err)
+	}
+
+	encoded, err := packet.Encode()
+	if err != nil {
+		t.Fatalf("Failed to encode space packet: %v", err)
+	}
+
+	decoded, err := spp.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Failed to decode space packet: %v", err)
+	}
+
+	if packet.PrimaryHeader != decoded.PrimaryHeader {
+		t.Errorf("Primary header does not match. Got %+v, want %+v", decoded.PrimaryHeader, packet.PrimaryHeader)
+	}
+
+	if !bytes.Equal(packet.UserData, decoded.UserData) {
+		t.Errorf("User data does not match. Got %v, want %v", decoded.UserData, packet.UserData)
+	}
+}
+
+func TestSpacePacketWithSecondaryHeader(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	secondaryHeader := spp.SecondaryHeader{Timestamp: 1234567890}
+	packet, err := spp.NewSpacePacket(100, data, spp.WithSecondaryHeader(secondaryHeader))
+	if err != nil {
+		t.Fatalf("Failed to create new space packet with secondary header: %v", err)
+	}
+
+	if packet.PrimaryHeader.SecondaryHeaderFlag != 1 {
+		t.Errorf("Expected SecondaryHeaderFlag 1, got %d", packet.PrimaryHeader.SecondaryHeaderFlag)
+	}
+
+	if packet.SecondaryHeader == nil || packet.SecondaryHeader.Timestamp != 1234567890 {
+		t.Errorf("Secondary header does not match. Got %+v, want %+v", packet.SecondaryHeader, secondaryHeader)
+	}
+}
+
+func TestSpacePacketWithErrorControl(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	crc := uint16(0xABCD)
+	packet, err := spp.NewSpacePacket(100, data, spp.WithErrorControl(crc))
+	if err != nil {
+		t.Fatalf("Failed to create new space packet with error control: %v", err)
+	}
+
+	if packet.ErrorControl == nil || *packet.ErrorControl != crc {
+		t.Errorf("Error control does not match. Got %v, want %v", packet.ErrorControl, crc)
+	}
+}
+
+func TestSendReceivePacket(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	packet, err := spp.NewSpacePacket(100, data)
+	if err != nil {
+		t.Fatalf("Failed to create new space packet: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = spp.SendPacket(packet, &buf)
+	if err != nil {
+		t.Fatalf("Failed to send space packet: %v", err)
+	}
+
+	receivedPacket, err := spp.ReceivePacket(&buf)
+	if err != nil {
+		t.Fatalf("Failed to receive space packet: %v", err)
+	}
+
+	if packet.PrimaryHeader != receivedPacket.PrimaryHeader {
+		t.Errorf("Primary header does not match. Got %+v, want %+v", receivedPacket.PrimaryHeader, packet.PrimaryHeader)
+	}
+
+	if !bytes.Equal(packet.UserData, receivedPacket.UserData) {
+		t.Errorf("User data does not match. Got %v, want %v", receivedPacket.UserData, packet.UserData)
+	}
+}

--- a/spp/packet_test.go
+++ b/spp/packet_test.go
@@ -2,6 +2,7 @@ package spp_test
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/ravisuhag/astro/spp"
 	"testing"
 )
@@ -35,6 +36,7 @@ func TestSpacePacketEncodeDecode(t *testing.T) {
 	}
 
 	decoded, err := spp.Decode(encoded)
+	fmt.Print(decoded.Humanize())
 	if err != nil {
 		t.Fatalf("Failed to decode space packet: %v", err)
 	}

--- a/spp/utils.go
+++ b/spp/utils.go
@@ -1,0 +1,21 @@
+package spp
+
+import (
+	"hash/crc32"
+	"strings"
+)
+
+// mapToString converts a map to a string representation.
+func mapToString(m map[string]interface{}) string {
+	var sb strings.Builder
+	for k, v := range m {
+		sb.WriteString(k + ": " + string(v.(string)) + "\n")
+	}
+	return sb.String()
+}
+
+// ComputeCRC computes the CRC checksum for the given data.
+func ComputeCRC(data []byte) uint16 {
+	checksum := crc32.ChecksumIEEE(data)
+	return uint16(checksum & 0xFFFF) // Return lower 16 bits of the checksum
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `spp` package, including the addition of new functionalities, error definitions, and comprehensive tests. It also includes updates to the repository's security policy and CI workflows.

### Summary of changes:

#### New functionalities and structures:
* [`spp/apid.go`](diffhunk://#diff-2f8a7303f94892b89eda03d38d33689b241032a3a3796b2d16b9021e555cf60dR1-R66): Added `APIDManager` for managing APID allocation and validation, including methods for reserving, releasing, and checking APIDs, as well as a function to describe APIDs.
* [`spp/header.go`](diffhunk://#diff-ce698ccf965fe97e7191a400074df1ab60ccfb3bed5e6959cdb0faca4bc15ba6R1-R190): Introduced `PrimaryHeader` and `SecondaryHeader` structures with methods for encoding, decoding, and generating human-readable representations.
* [`spp/packet.go`](diffhunk://#diff-c76690e5d62e3330f977ebbe25337effd089ba8ea673d8975f00495c5df9a7d2R1-R229): Added `SpacePacket` structure representing a complete space packet, including methods for encoding, decoding, sending, and receiving packets, as well as generating human-readable representations.

#### Error definitions:
* [`spp/errors.go`](diffhunk://#diff-068e313da73faee0829cbae30bc2863f388d8a8a25b6d9027ad692f17ebf5792R1-R25): Defined custom error messages for the `spp` package, including errors for invalid headers, APIDs, packet sizes, data lengths, missing secondary headers, and CRC validation failures.

#### Testing:
* [`spp/apid_test.go`](diffhunk://#diff-147be979d2535a4f7619c16cd898bc205331a13c5e8638df49e4c09fdac2ce3bR1-R87): Added tests for `APIDManager` methods to ensure proper functionality of reserving, releasing, and checking APIDs.
* [`spp/header_test.go`](diffhunk://#diff-29f81d5f0dd867921f8b0e7f6365a58b9c7872f768872cdbc6cd281df781fff2R1-R147): Added tests for encoding and decoding of `PrimaryHeader` and `SecondaryHeader` structures, including edge cases for various fields.

#### Repository updates:
* [`.github/SECURITY.md`](diffhunk://#diff-ac3050733d58345444c27d37c6247ef260ad992bcb02782feea43fb580106079R1-R11): Added instructions for reporting security vulnerabilities, emphasizing private reporting and providing a link for private vulnerability reporting.
* [`.github/workflows/lint.yaml`](diffhunk://#diff-98865848100ed13ce199b207df9b2486cdbeefd40d87c578565acab1a986095dR1-R29): Introduced a new GitHub Actions workflow for linting Go files, including setup steps and the use of `golangci-lint`.
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R1-R22): Added a new GitHub Actions workflow for running unit tests on push and pull request events, including setup steps for Go.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R1-R3): Defined the Go module for the project and specified the Go version.